### PR TITLE
Use portable versions of sprintf, sscanf, etc, and add a draft Makefile for non-Windows builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,5 @@ FodyWeavers.xsd
 *.so
 *.dll
 *.dylib
+*.o
+*.a

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+*.so
+*.dll
+*.dylib

--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,20 @@ SOURCES += human_readable_map16.cpp
 ifeq ($(PLATFORM),)
   ifeq ($(OS),Windows_NT)
     PLATFORM = windows
+    ARCH ?= $(PROCESSOR_ARCHITECTURE)
   else
     UNAME = $(shell uname -s)
     ifeq ($(UNAME),Darwin)
       PLATFORM = macos
+      ARCH ?= $(shell uname -m)
     else ifeq ($(UNAME),Linux)
       PLATFORM = linux
+      ARCH ?= $(shell uname -m)
     else
       PLATFORM = unknown
     endif
   endif
 endif
-
-ARCH ?= $(shell uname -m)
 
 ifeq ($(PLATFORM),unknown)
   $(error unknown platform, please specify PLATFORM= windows, macos, or linux)
@@ -30,29 +31,44 @@ endif
 
 ifeq ($(PLATFORM),windows)
   LIBEXT = dll
+  STATIC_LIBEXT = lib
 endif
-
 ifeq ($(PLATFORM),macos)
   LIBEXT = dylib
+  STATIC_LIBEXT = a
 endif
-
 ifeq ($(PLATFORM),linux)
   LIBEXT = so
+  STATIC_LIBEXT = a
 endif
-
-LIB = human_readable_map16.$(LIBEXT)
-
-.PHONY: all
-all: $(LIB)
 
 FLAGS += $(CPPFLAGS)
 FLAGS += -Wall
 FLAGS += --std=c++17
 
-$(LIB): $(SOURCES)
-	$(CXX) -dynamiclib $(FLAGS) $(SOURCES) -o $@
+ifeq ($(STATIC),1)
+  LIB = human_readable_map16.$(STATIC_LIBEXT)
+  $(LIB): $(SOURCES)
+	$(CXX) $(FLAGS) -c $(SOURCES)
+	$(AR) rcs $@ *.o
+else
+  LIB = human_readable_map16.$(LIBEXT)
+  ifeq ($(PLATFORM),windows)
+    DYNFLAG = -shared
+  endif
+  ifeq ($(PLATFORM),macos)
+    DYNFLAG = -dynamiclib
+  endif
+  ifeq ($(PLATFORM),linux)
+    DYNFLAG = -shared -fPIC
+  endif
+  $(LIB): $(SOURCES)
+	$(CXX) $(DYNFLAG) $(FLAGS) $(SOURCES) -o $@
+endif
+
+.PHONY: all
+all: $(LIB)
 
 .PHONY: clean
 clean:
 	rm -f $(LIB)
-

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ FLAGS += $(CPPFLAGS)
 FLAGS += -Wall
 FLAGS += --std=c++17
 
-$(LIB):
+$(LIB): $(SOURCES)
 	$(CXX) -dynamiclib $(FLAGS) $(SOURCES) -o $@
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,8 @@ ifeq ($(PLATFORM),)
     UNAME = $(shell uname -s)
     ifeq ($(UNAME),Darwin)
       PLATFORM = macos
-      LIBEXT = dylib
     else ifeq ($(UNAME),Linux)
       PLATFORM = linux
-      LIBEXT = so
     else
       PLATFORM = unknown
     endif
@@ -28,6 +26,18 @@ ifeq ($(PLATFORM),unknown)
   $(error unknown platform, please specify PLATFORM= windows, macos, or linux)
 else
   $(info ==========  building for $(PLATFORM)-$(ARCH) ============)
+endif
+
+ifeq ($(PLATFORM),windows)
+  LIBEXT = dll
+endif
+
+ifeq ($(PLATFORM),macos)
+  LIBEXT = dylib
+endif
+
+ifeq ($(PLATFORM),linux)
+  LIBEXT = so
 endif
 
 LIB = human_readable_map16.$(LIBEXT)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: default
+default: all
+
+SOURCES += from_map16.cpp
+SOURCES += to_map16.cpp
+SOURCES += human_readable_map16.cpp
+
+ifeq ($(PLATFORM),)
+  ifeq ($(OS),Windows_NT)
+    PLATFORM = windows
+  else
+    UNAME = $(shell uname -s)
+    ifeq ($(UNAME),Darwin)
+      PLATFORM = macos
+      LIBEXT = dylib
+    else ifeq ($(UNAME),Linux)
+      PLATFORM = linux
+      LIBEXT = so
+    else
+      PLATFORM = unknown
+    endif
+  endif
+endif
+
+ARCH ?= $(shell uname -m)
+
+ifeq ($(PLATFORM),unknown)
+  $(error unknown platform, please specify PLATFORM= windows, macos, or linux)
+else
+  $(info ==========  building for $(PLATFORM)-$(ARCH) ============)
+endif
+
+LIB = human_readable_map16.$(LIBEXT)
+
+.PHONY: all
+all: $(LIB)
+
+FLAGS += $(CPPFLAGS)
+FLAGS += -Wall
+FLAGS += --std=c++17
+
+$(LIB):
+	$(CXX) -dynamiclib $(FLAGS) $(SOURCES) -o $@
+
+.PHONY: clean
+clean:
+	rm -f $(LIB)
+

--- a/from_map16.cpp
+++ b/from_map16.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "human_readable_map16.h"
 #include "arrays.h"
+#include <iterator>
 
 HumanReadableMap16::_4Bytes HumanReadableMap16::from_map16::join_bytes(ByteIterator begin, ByteIterator end) {
 	_4Bytes t = 0;

--- a/from_map16.cpp
+++ b/from_map16.cpp
@@ -131,7 +131,7 @@ void HumanReadableMap16::from_map16::convert_to_file(FILE* fp, unsigned int tile
 void HumanReadableMap16::from_map16::convert_FG_page(std::vector<Byte> map16_buffer, unsigned int page_number,
 	size_t tiles_start_offset, size_t acts_like_start_offset) {
 	char filename[256];
-	sprintf(filename, "global_pages\\FG_pages\\page_%02X.txt", page_number);
+	sprintf(filename, "global_pages" SEP "FG_pages" SEP "page_%02X.txt", page_number);
 	FILE* fp = fopen(filename, "w");
 	unsigned int curr_tile_number = page_number * PAGE_SIZE;
 	auto curr_tile_it = map16_buffer.begin() + tiles_start_offset + PAGE_SIZE * _16x16_BYTE_SIZE * page_number;
@@ -159,7 +159,7 @@ void HumanReadableMap16::from_map16::convert_FG_page(std::vector<Byte> map16_buf
 }
 
 void HumanReadableMap16::from_map16::convert_global_page_2_for_tileset_specific_page_2s(std::vector<Byte> map16_buffer, size_t acts_like_offset) {
-	FILE* fp = fopen("global_pages\\FG_pages\\page_02.txt", "w");
+	FILE* fp = fopen("global_pages" SEP "FG_pages" SEP "page_02.txt", "w");
 
 	auto curr_acts_like_it = map16_buffer.begin() + acts_like_offset + PAGE_SIZE * ACTS_LIKE_SIZE * 2;
 
@@ -183,7 +183,7 @@ void HumanReadableMap16::from_map16::convert_global_page_2_for_tileset_specific_
 
 void HumanReadableMap16::from_map16::convert_BG_page(std::vector<Byte> map16_buffer, unsigned int page_number, size_t tiles_start_offset) {
 	char filename[256];
-	sprintf(filename, "global_pages\\BG_pages\\page_%02X.txt", page_number);
+	sprintf(filename, "global_pages" SEP "BG_pages" SEP "page_%02X.txt", page_number);
 	FILE* fp = fopen(filename, "w");
 	unsigned int curr_tile_number = page_number * PAGE_SIZE;
 	auto curr_tile_it = map16_buffer.begin() + tiles_start_offset + PAGE_SIZE * _16x16_BYTE_SIZE * page_number;
@@ -210,7 +210,7 @@ void HumanReadableMap16::from_map16::convert_BG_page(std::vector<Byte> map16_buf
 void HumanReadableMap16::from_map16::convert_tileset_group_specific_pages(std::vector<Byte> map16_buffer, unsigned int tileset_group_number,
 	size_t tiles_start_offset, size_t diagonal_pipes_offset) {
 	char filename[256];
-	sprintf(filename, "tileset_group_specific_tiles\\tileset_group_%X.txt", tileset_group_number);
+	sprintf(filename, "tileset_group_specific_tiles" SEP "tileset_group_%X.txt", tileset_group_number);
 	FILE* fp = fopen(filename, "w");
 
 	auto curr_tile_it = map16_buffer.begin() + tiles_start_offset + PAGE_SIZE * _16x16_BYTE_SIZE * 2 * tileset_group_number + _16x16_BYTE_SIZE * TILESET_GROUP_SPECIFIC_TILES.at(0);
@@ -261,7 +261,7 @@ void HumanReadableMap16::from_map16::convert_tileset_group_specific_pages(std::v
 
 void HumanReadableMap16::from_map16::convert_tileset_specific_page_2(std::vector<Byte> map16_buffer, unsigned int tileset_number, size_t tiles_start_offset) {
 	char filename[256];
-	sprintf(filename, "tileset_specific_tiles\\tileset_%X.txt", tileset_number);
+	sprintf(filename, "tileset_specific_tiles" SEP "tileset_%X.txt", tileset_number);
 	FILE* fp = fopen(filename, "w");
 
 	unsigned int base_tile_number = 0x200;
@@ -290,7 +290,7 @@ void HumanReadableMap16::from_map16::convert_tileset_specific_page_2(std::vector
 
 void HumanReadableMap16::from_map16::convert_normal_pipe_tiles(std::vector<Byte> map16_buffer, unsigned int pipe_number, size_t normal_pipe_offset) {
 	char filename[256];
-	sprintf(filename, "pipe_tiles\\pipe_%X.txt", pipe_number);
+	sprintf(filename, "pipe_tiles" SEP "pipe_%X.txt", pipe_number);
 	FILE* fp = fopen(filename, "w");
 
 	auto curr_tile_it = map16_buffer.begin() + normal_pipe_offset + _16x16_BYTE_SIZE * 8 * pipe_number;
@@ -316,8 +316,8 @@ void HumanReadableMap16::from_map16::convert_normal_pipe_tiles(std::vector<Byte>
 void HumanReadableMap16::from_map16::convert_first_two_non_tileset_specific(std::vector<Byte> map16_buffer,
 	size_t tileset_group_specific_offset, size_t acts_like_offset) {
 
-	FILE* fp1 = fopen("global_pages\\FG_pages\\page_00.txt", "w");
-	FILE* fp2 = fopen("global_pages\\FG_pages\\page_01.txt", "w");
+	FILE* fp1 = fopen("global_pages" SEP "FG_pages" SEP "page_00.txt", "w");
+	FILE* fp2 = fopen("global_pages" SEP "FG_pages" SEP "page_01.txt", "w");
 
 	std::unordered_set<_2Bytes> tileset_group_specific = std::unordered_set<_2Bytes>(TILESET_GROUP_SPECIFIC_TILES.begin(), TILESET_GROUP_SPECIFIC_TILES.end());
 
@@ -429,8 +429,8 @@ void HumanReadableMap16::from_map16::convert(const fs::path input_file, const fs
 		write_header_file(header, "header.txt");
 
 		fs::create_directory("global_pages");
-		fs::create_directory("global_pages\\FG_pages");
-		fs::create_directory("global_pages\\BG_pages");
+		fs::create_directory("global_pages" SEP "FG_pages");
+		fs::create_directory("global_pages" SEP "BG_pages");
 		fs::create_directory("tileset_group_specific_tiles");
 
 		if (has_tileset_specific_page_2s(header)) {

--- a/from_map16.cpp
+++ b/from_map16.cpp
@@ -78,7 +78,7 @@ bool HumanReadableMap16::from_map16::try_LM_empty_convert(FILE* fp, unsigned int
 		return false;
 	}
 
-	fprintf_s(fp, LM_EMPTY_TILE_FORMAT, tile_number);
+	fprintf(fp, LM_EMPTY_TILE_FORMAT, tile_number);
 
 	return true;
 }
@@ -99,7 +99,7 @@ void HumanReadableMap16::from_map16::convert_to_file(FILE* fp, unsigned int tile
 		return;
 	}
 
-	fprintf_s(fp, STANDARD_FORMAT,
+	fprintf(fp, STANDARD_FORMAT,
 		tile_number, acts_like,
 		TILE_FORMAT(tile1),
 		TILE_FORMAT(tile2),
@@ -109,7 +109,7 @@ void HumanReadableMap16::from_map16::convert_to_file(FILE* fp, unsigned int tile
 }
 
 void HumanReadableMap16::from_map16::convert_to_file(FILE* fp, unsigned int tile_number, _2Bytes acts_like) {
-	fprintf_s(fp, NO_TILES_FORMAT,
+	fprintf(fp, NO_TILES_FORMAT,
 		tile_number, acts_like
 	);
 }
@@ -119,7 +119,7 @@ void HumanReadableMap16::from_map16::convert_to_file(FILE* fp, unsigned int tile
 		return;
 	}
 
-	fprintf_s(fp, NO_ACTS_FORMAT,
+	fprintf(fp, NO_ACTS_FORMAT,
 		tile_number,
 		TILE_FORMAT(tile1),
 		TILE_FORMAT(tile2),
@@ -130,10 +130,9 @@ void HumanReadableMap16::from_map16::convert_to_file(FILE* fp, unsigned int tile
 
 void HumanReadableMap16::from_map16::convert_FG_page(std::vector<Byte> map16_buffer, unsigned int page_number,
 	size_t tiles_start_offset, size_t acts_like_start_offset) {
-	FILE* fp;
 	char filename[256];
-	sprintf_s(filename, "global_pages\\FG_pages\\page_%02X.txt", page_number);
-	fopen_s(&fp, filename, "w");
+	sprintf(filename, "global_pages\\FG_pages\\page_%02X.txt", page_number);
+	FILE* fp = fopen(filename, "w");
 	unsigned int curr_tile_number = page_number * PAGE_SIZE;
 	auto curr_tile_it = map16_buffer.begin() + tiles_start_offset + PAGE_SIZE * _16x16_BYTE_SIZE * page_number;
 	auto curr_acts_like_it = map16_buffer.begin() + acts_like_start_offset + PAGE_SIZE * ACTS_LIKE_SIZE * page_number;
@@ -148,7 +147,7 @@ void HumanReadableMap16::from_map16::convert_FG_page(std::vector<Byte> map16_buf
 		convert_to_file(fp, curr_tile_number, acts_like, tile1, tile2, tile3, tile4);
 
 		if (i != PAGE_SIZE - 1) {
-			fprintf_s(fp, "\n");
+			fprintf(fp, "\n");
 		}
 
 		++curr_tile_number;
@@ -160,8 +159,7 @@ void HumanReadableMap16::from_map16::convert_FG_page(std::vector<Byte> map16_buf
 }
 
 void HumanReadableMap16::from_map16::convert_global_page_2_for_tileset_specific_page_2s(std::vector<Byte> map16_buffer, size_t acts_like_offset) {
-	FILE* fp;
-	fopen_s(&fp, "global_pages\\FG_pages\\page_02.txt", "w");
+	FILE* fp = fopen("global_pages\\FG_pages\\page_02.txt", "w");
 
 	auto curr_acts_like_it = map16_buffer.begin() + acts_like_offset + PAGE_SIZE * ACTS_LIKE_SIZE * 2;
 
@@ -173,7 +171,7 @@ void HumanReadableMap16::from_map16::convert_global_page_2_for_tileset_specific_
 		convert_to_file(fp, curr_tile_number, acts_like);
 
 		if (i != PAGE_SIZE - 1) {
-			fprintf_s(fp, "\n");
+			fprintf(fp, "\n");
 		}
 
 		++curr_tile_number;
@@ -184,10 +182,9 @@ void HumanReadableMap16::from_map16::convert_global_page_2_for_tileset_specific_
 }
 
 void HumanReadableMap16::from_map16::convert_BG_page(std::vector<Byte> map16_buffer, unsigned int page_number, size_t tiles_start_offset) {
-	FILE* fp;
 	char filename[256];
-	sprintf_s(filename, "global_pages\\BG_pages\\page_%02X.txt", page_number);
-	fopen_s(&fp, filename, "w");
+	sprintf(filename, "global_pages\\BG_pages\\page_%02X.txt", page_number);
+	FILE* fp = fopen(filename, "w");
 	unsigned int curr_tile_number = page_number * PAGE_SIZE;
 	auto curr_tile_it = map16_buffer.begin() + tiles_start_offset + PAGE_SIZE * _16x16_BYTE_SIZE * page_number;
 
@@ -203,7 +200,7 @@ void HumanReadableMap16::from_map16::convert_BG_page(std::vector<Byte> map16_buf
 		curr_tile_it += _16x16_BYTE_SIZE;
 
 		if (i != PAGE_SIZE - 1) {
-			fprintf_s(fp, "\n");
+			fprintf(fp, "\n");
 		}
 	}
 
@@ -212,10 +209,9 @@ void HumanReadableMap16::from_map16::convert_BG_page(std::vector<Byte> map16_buf
 
 void HumanReadableMap16::from_map16::convert_tileset_group_specific_pages(std::vector<Byte> map16_buffer, unsigned int tileset_group_number,
 	size_t tiles_start_offset, size_t diagonal_pipes_offset) {
-	FILE* fp;
 	char filename[256];
-	sprintf_s(filename, "tileset_group_specific_tiles\\tileset_group_%X.txt", tileset_group_number);
-	fopen_s(&fp, filename, "w");
+	sprintf(filename, "tileset_group_specific_tiles\\tileset_group_%X.txt", tileset_group_number);
+	FILE* fp = fopen(filename, "w");
 
 	auto curr_tile_it = map16_buffer.begin() + tiles_start_offset + PAGE_SIZE * _16x16_BYTE_SIZE * 2 * tileset_group_number + _16x16_BYTE_SIZE * TILESET_GROUP_SPECIFIC_TILES.at(0);
 
@@ -230,7 +226,7 @@ void HumanReadableMap16::from_map16::convert_tileset_group_specific_pages(std::v
 		convert_to_file(fp, tile_number, tile1, tile2, tile3, tile4);
 
 		if (i != TILESET_GROUP_SPECIFIC_TILES.size() - 1) {
-			fprintf_s(fp, "\n");
+			fprintf(fp, "\n");
 		}
 
 		try {
@@ -253,7 +249,7 @@ void HumanReadableMap16::from_map16::convert_tileset_group_specific_pages(std::v
 			convert_to_file(fp, tile_number, tile1, tile2, tile3, tile4);
 
 			if (tile_number != DIAGONAL_PIPE_TILES.back()) {
-				fprintf_s(fp, "\n");
+				fprintf(fp, "\n");
 			}
 
 			diag_pipe_it += _16x16_BYTE_SIZE;
@@ -264,10 +260,9 @@ void HumanReadableMap16::from_map16::convert_tileset_group_specific_pages(std::v
 }
 
 void HumanReadableMap16::from_map16::convert_tileset_specific_page_2(std::vector<Byte> map16_buffer, unsigned int tileset_number, size_t tiles_start_offset) {
-	FILE* fp;
 	char filename[256];
-	sprintf_s(filename, "tileset_specific_tiles\\tileset_%X.txt", tileset_number);
-	fopen_s(&fp, filename, "w");
+	sprintf(filename, "tileset_specific_tiles\\tileset_%X.txt", tileset_number);
+	FILE* fp = fopen(filename, "w");
 
 	unsigned int base_tile_number = 0x200;
 
@@ -284,7 +279,7 @@ void HumanReadableMap16::from_map16::convert_tileset_specific_page_2(std::vector
 		convert_to_file(fp, tile_number, tile1, tile2, tile3, tile4);
 
 		if (i != PAGE_SIZE - 1) {
-			fprintf_s(fp, "\n");
+			fprintf(fp, "\n");
 		}
 
 		curr_tile_it += _16x16_BYTE_SIZE;
@@ -294,10 +289,9 @@ void HumanReadableMap16::from_map16::convert_tileset_specific_page_2(std::vector
 }
 
 void HumanReadableMap16::from_map16::convert_normal_pipe_tiles(std::vector<Byte> map16_buffer, unsigned int pipe_number, size_t normal_pipe_offset) {
-	FILE* fp;
 	char filename[256];
-	sprintf_s(filename, "pipe_tiles\\pipe_%X.txt", pipe_number);
-	fopen_s(&fp, filename, "w");
+	sprintf(filename, "pipe_tiles\\pipe_%X.txt", pipe_number);
+	FILE* fp = fopen(filename, "w");
 
 	auto curr_tile_it = map16_buffer.begin() + normal_pipe_offset + _16x16_BYTE_SIZE * 8 * pipe_number;
 
@@ -310,7 +304,7 @@ void HumanReadableMap16::from_map16::convert_normal_pipe_tiles(std::vector<Byte>
 		convert_to_file(fp, tile_number, tile1, tile2, tile3, tile4);
 
 		if (tile_number != NORMAL_PIPE_TILES.back()) {
-			fprintf_s(fp, "\n");
+			fprintf(fp, "\n");
 		}
 
 		curr_tile_it += _16x16_BYTE_SIZE;
@@ -322,10 +316,8 @@ void HumanReadableMap16::from_map16::convert_normal_pipe_tiles(std::vector<Byte>
 void HumanReadableMap16::from_map16::convert_first_two_non_tileset_specific(std::vector<Byte> map16_buffer,
 	size_t tileset_group_specific_offset, size_t acts_like_offset) {
 
-	FILE* fp1;
-	FILE* fp2;
-	fopen_s(&fp1, "global_pages\\FG_pages\\page_00.txt", "w");
-	fopen_s(&fp2, "global_pages\\FG_pages\\page_01.txt", "w");
+	FILE* fp1 = fopen("global_pages\\FG_pages\\page_00.txt", "w");
+	FILE* fp2 = fopen("global_pages\\FG_pages\\page_01.txt", "w");
 
 	std::unordered_set<_2Bytes> tileset_group_specific = std::unordered_set<_2Bytes>(TILESET_GROUP_SPECIFIC_TILES.begin(), TILESET_GROUP_SPECIFIC_TILES.end());
 
@@ -355,7 +347,7 @@ void HumanReadableMap16::from_map16::convert_first_two_non_tileset_specific(std:
 		}
 
 		if (i != (PAGE_SIZE * 2) - 1) {
-			fprintf_s(fp, "\n");
+			fprintf(fp, "\n");
 		}
 
 		curr_tile_it += _16x16_BYTE_SIZE;
@@ -367,8 +359,7 @@ void HumanReadableMap16::from_map16::convert_first_two_non_tileset_specific(std:
 }
 
 void HumanReadableMap16::from_map16::write_header_file(std::shared_ptr<Header> header, const fs::path header_path) {
-	FILE* fp;
-	fopen_s(&fp, header_path.string().c_str(), "w");
+	FILE* fp = fopen(header_path.string().c_str(), "w");
 
 	fprintf(
 		fp,
@@ -433,7 +424,7 @@ void HumanReadableMap16::from_map16::convert(const fs::path input_file, const fs
 	try {
 		fs::remove_all(output_path);
 		fs::create_directory(output_path);
-		_wchdir(output_path.c_str());
+		fs::current_path(output_path);
 
 		write_header_file(header, "header.txt");
 

--- a/human_readable_map16.h
+++ b/human_readable_map16.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#ifdef _WIN32
+#define SEP "\\"
+#else
+#define SEP "/"
+#endif
+
 #include <vector>
 #include <string>
 #include <fstream>

--- a/to_map16.cpp
+++ b/to_map16.cpp
@@ -4,6 +4,7 @@
 #include "tile_error.h"
 #include "header_error.h"
 #include "arrays.h"
+#include <algorithm>
 
 std::shared_ptr<HumanReadableMap16::Header> HumanReadableMap16::to_map16::parse_header_file(const fs::path header_path) {
 	verify_header_file(header_path);

--- a/to_map16.cpp
+++ b/to_map16.cpp
@@ -636,11 +636,11 @@ std::vector<fs::path> HumanReadableMap16::to_map16::get_sorted_paths(const fs::p
 }
 
 unsigned int HumanReadableMap16::to_map16::parse_BG_pages(std::vector<Byte>& bg_tiles_vec, unsigned int base_tile_number) {
-	if (!fs::exists("global_pages\\BG_pages")) {
-		throw FilesystemError("Expected directory appears to be missing", fs::path("global_pages\\BG_pages"));
+	if (!fs::exists("global_pages" SEP "BG_pages")) {
+		throw FilesystemError("Expected directory appears to be missing", fs::path("global_pages" SEP "BG_pages"));
 	}
 
-	const auto sorted_paths = get_sorted_paths("global_pages\\BG_pages");
+	const auto sorted_paths = get_sorted_paths("global_pages" SEP "BG_pages");
 
 	unsigned int curr_tile_number = base_tile_number;
 
@@ -665,11 +665,11 @@ unsigned int HumanReadableMap16::to_map16::parse_BG_pages(std::vector<Byte>& bg_
 }
 
 unsigned int HumanReadableMap16::to_map16::parse_FG_pages(std::vector<Byte>& fg_tiles_vec, std::vector<Byte>& acts_like_vec, unsigned int base_tile_number) {
-	if (!fs::exists("global_pages\\FG_pages")) {
-		throw FilesystemError("Expected directory appears to be missing", fs::path("global_pages\\FG_pages"));
+	if (!fs::exists("global_pages" SEP "FG_pages")) {
+		throw FilesystemError("Expected directory appears to be missing", fs::path("global_pages" SEP "FG_pages"));
 	}
 
-	const auto sorted_paths = get_sorted_paths("global_pages\\FG_pages");
+	const auto sorted_paths = get_sorted_paths("global_pages" SEP "FG_pages");
 
 	unsigned int curr_tile_number = base_tile_number;
 
@@ -703,11 +703,11 @@ unsigned int HumanReadableMap16::to_map16::parse_FG_pages(std::vector<Byte>& fg_
 
 unsigned int HumanReadableMap16::to_map16::parse_FG_pages_tileset_specific_page_2(std::vector<Byte>& fg_tiles_vec, std::vector<Byte>& acts_like_vec,
 	std::vector<Byte>& tileset_specific_tiles_vec, unsigned int base_tile_number) {
-	if (!fs::exists("global_pages\\FG_pages")) {
-		throw FilesystemError("Expected directory appears to be missing", fs::path("global_pages\\FG_pages"));
+	if (!fs::exists("global_pages" SEP "FG_pages")) {
+		throw FilesystemError("Expected directory appears to be missing", fs::path("global_pages" SEP "FG_pages"));
 	}
 
-	const auto sorted_paths = get_sorted_paths("global_pages\\FG_pages");
+	const auto sorted_paths = get_sorted_paths("global_pages" SEP "FG_pages");
 
 	unsigned int curr_tile_number = base_tile_number;
 

--- a/to_map16.cpp
+++ b/to_map16.cpp
@@ -8,14 +8,13 @@
 std::shared_ptr<HumanReadableMap16::Header> HumanReadableMap16::to_map16::parse_header_file(const fs::path header_path) {
 	verify_header_file(header_path);
 
-	FILE* fp;
-	fopen_s(&fp, header_path.string().c_str(), "r");
+	FILE* fp = fopen(header_path.string().c_str(), "r");
 
 	auto header = std::make_shared<Header>();
 
 	unsigned int is_full_game_export, has_tileset_specific_page_2;
 
-	fscanf_s(fp,
+	fscanf(fp,
 		"file_format_version_number: %X\n" \
 		"game_id: %X\n" \
 		"program_version: %X\n" \
@@ -192,7 +191,7 @@ void HumanReadableMap16::to_map16::split_and_insert_4(_4Bytes bytes, std::vector
 bool HumanReadableMap16::to_map16::try_LM_empty_convert_full(std::vector<Byte>& tiles_vec, std::vector<Byte>& acts_like_vec, 
 	const std::string line, unsigned int expected_tile_number) {
 	char buf[256];
-	sprintf_s(buf, LM_EMTPY_TILE_FORMAT_NO_NEWLINE, expected_tile_number);
+	snprintf(buf, 256, LM_EMTPY_TILE_FORMAT_NO_NEWLINE, expected_tile_number);
 	std::string expected_line = buf;
 
 	if (expected_line != line) {
@@ -210,7 +209,7 @@ bool HumanReadableMap16::to_map16::try_LM_empty_convert_full(std::vector<Byte>& 
 
 bool HumanReadableMap16::to_map16::try_LM_empty_convert_tiles_only(std::vector<Byte>& tiles_vec, const std::string line, unsigned int expected_tile_number) {
 	char buf[256];
-	sprintf_s(buf, LM_EMTPY_TILE_FORMAT_NO_NEWLINE, expected_tile_number);
+	sprintf(buf, LM_EMTPY_TILE_FORMAT_NO_NEWLINE, expected_tile_number);
 	std::string expected_line = buf;
 
 	if (expected_line != line) {
@@ -245,7 +244,7 @@ void HumanReadableMap16::to_map16::convert_full(std::vector<Byte>& tiles_vec, st
 		_8x8_tile_3, palette_3, _8x8_tile_4, palette_4;
 	char x_1, x_2, x_3, x_4, y_1, y_2, y_3, y_4, p_1, p_2, p_3, p_4;
 
-	sscanf_s(line.c_str(), STANDARD_FORMAT,
+	sscanf(line.c_str(), STANDARD_FORMAT,
 		&_16x16_tile_number, &acts_like,
 		&_8x8_tile_1, &palette_1, &x_1, 1, &y_1, 1, &p_1, 1,
 		&_8x8_tile_2, &palette_2, &x_2, 1, &y_2, 1, &p_2, 1,
@@ -365,7 +364,7 @@ void HumanReadableMap16::to_map16::verify_8x8_tiles(const std::string line, unsi
 void HumanReadableMap16::to_map16::verify_tile_number(const std::string line, unsigned int line_number, const fs::path file, unsigned int& curr_char_idx,
 	TileFormat tile_format, unsigned int expected_tile_number) {
 	char tile_number_part[7];
-	sprintf_s(tile_number_part, "%04X: ", expected_tile_number);
+	sprintf(tile_number_part, "%04X: ", expected_tile_number);
 	std::string tile_number_p = std::string(tile_number_part);
 
 	for (const char c : tile_number_p) {
@@ -406,7 +405,7 @@ void HumanReadableMap16::to_map16::verify_acts_like(const std::string line, unsi
 	}
 
 	unsigned int acts_digit_1, acts_digit_2, acts_digit_3;
-	unsigned int res = sscanf_s(acts_like.c_str(), "%1X%1X%1X", &acts_digit_1, &acts_digit_2, &acts_digit_3);
+	unsigned int res = sscanf(acts_like.c_str(), "%1X%1X%1X", &acts_digit_1, &acts_digit_2, &acts_digit_3);
 
 	bool is_all_uppercase = std::all_of(acts_like.begin(), acts_like.end(), [](unsigned char c) { return std::isupper(c) || std::isdigit(c); });
 
@@ -459,7 +458,7 @@ void HumanReadableMap16::to_map16::verify_8x8_tile(const std::string line, unsig
 	unsigned int _8x8_tile_digit_1, _8x8_tile_digit_2, _8x8_tile_digit_3, palette;
 	char x, y, p;
 
-	unsigned int res = sscanf_s(tile_substr.c_str(), "%1X%1X%1X %X %c%c%c",
+	unsigned int res = sscanf(tile_substr.c_str(), "%1X%1X%1X %X %c%c%c",
 		&_8x8_tile_digit_1, &_8x8_tile_digit_2, &_8x8_tile_digit_3, &palette,
 		&x, 1, &y, 1, &p, 1
 	);
@@ -513,7 +512,7 @@ void HumanReadableMap16::to_map16::convert_acts_like_only(std::vector<Byte>& act
 
 	unsigned int _16x16_tile_number, acts_like;
 
-	sscanf_s(line.c_str(), NO_TILES_FORMAT,
+	sscanf(line.c_str(), NO_TILES_FORMAT,
 		&_16x16_tile_number, &acts_like
 	);
 
@@ -558,7 +557,7 @@ void HumanReadableMap16::to_map16::convert_tiles_only(std::vector<Byte>& tiles_v
 		_8x8_tile_3, palette_3, _8x8_tile_4, palette_4;
 	char x_1, x_2, x_3, x_4, y_1, y_2, y_3, y_4, p_1, p_2, p_3, p_4;
 
-	sscanf_s(line.c_str(), NO_ACTS_FORMAT,
+	sscanf(line.c_str(), NO_ACTS_FORMAT,
 		&_16x16_tile_number,
 		&_8x8_tile_1, &palette_1, &x_1, 1, &y_1, 1, &p_1, 1,
 		&_8x8_tile_2, &palette_2, &x_2, 1, &y_2, 1, &p_2, 1,
@@ -973,7 +972,7 @@ void HumanReadableMap16::to_map16::convert(const fs::path input_path, const fs::
 		throw FilesystemError("Input path does not appear to be a directory", input_path);
 	}
 
-	_wchdir(input_path.c_str());
+	fs::current_path(input_path);
 
 	auto header = parse_header_file("header.txt");
 
@@ -1016,7 +1015,7 @@ void HumanReadableMap16::to_map16::convert(const fs::path input_path, const fs::
 	const auto combined = combine(header_vec, offset_size_vec, fg_tiles_vec, bg_tiles_vec, acts_like_vec, tileset_specific_vec,
 		tileset_group_specific_vec, pipe_tiles_vec, diagonal_pipe_tiles_vec);
 
-	_wchdir(original_working_dir.c_str());
+	fs::current_path(original_working_dir);
 
 	std::ofstream map16_file(output_file, std::ios::out | std::ios::binary);
 	map16_file.write(reinterpret_cast<const char *>(combined.data()), combined.size());


### PR DESCRIPTION
The following functions were not portable:

```
sprintf_s, fprintf_s, sscanf_s, fopen_s, _wchdir
```

I have managed to get this to compile on MacOS by replacing these with their portable versions - there are still a number of warnings related to type mismatches between template markers and pointers passed to sscanf, and I will need to test the behaviour of those.